### PR TITLE
Makefile add clean and index targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ recce[.]toc
 recce[.]idx
 recce[.]ilg
 recce[.]ind
+recce[.]dvi

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,10 @@ recce.idx: recce.ltx
 	
 ah2002_notes.pdf: ah2002_notes.ltx
 	pdflatex $?
+
+realclean: clean
+	rm -f *.pdf
+
+clean:
+	rm -f *.log *.aux *.ilg *.idx *.ind *.toc *.dvi
+

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ recce.pdf: recce.ltx recce.ind
 
 recce.ind: recce.idx
 	makeindex recce
-
+	
+recce.idx: recce.ltx
+	pdflatex $?
+	mv recce.log recce.idx.log
+	rm -f recce.pdf
+	
 ah2002_notes.pdf: ah2002_notes.ltx
 	pdflatex $?


### PR DESCRIPTION
make doesn't run on freshly cloned repo due to missing recce.idx target, hence the patch; clean targets are actually a nit, but hopefully useful one.
